### PR TITLE
Latex preamble

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -208,9 +208,10 @@ Most functions accept a cell specification as positional argument. Below we use 
       #callisto.render(
         nb: json("notebook.ipynb"),
         handlers: (
-          "text/markdown": cmarker.render.with(
-              math: mitex,
-              scope: (image: (path, alt: none) => image(path, alt: alt)),
+          "image/x.path": (path, alt: none) => image(path, alt: alt),
+          "text/markdown": (data, ..args) => cmarker.render(data,
+              math: callisto.mitex-with-preamble.with(mitex-preamble: args.at("mitex-preamble", default: "")),
+              scope: (image: callisto.image-markdown-cell.with(..args)),
           ),
         ),
       )

--- a/src/callisto.typ
+++ b/src/callisto.typ
@@ -1,5 +1,5 @@
 #import "reading.typ"
-#import "reading.typ": cells, cell, outputs, output, displays, display, results, result, stream-items, stream-item, errors, error, streams, stream, sources, source, read-mime, image-markdown-cell
+#import "reading.typ": cells, cell, outputs, output, displays, display, results, result, stream-items, stream-item, errors, error, streams, stream, sources, source, read-mime, image-markdown-cell, mitex-with-preamble
 #import "rendering.typ"
 #import "rendering.typ": render, Cell, In, Out
 

--- a/src/reading.typ
+++ b/src/reading.typ
@@ -61,7 +61,7 @@
 // Handler for Markdown markup
 #let handler-markdown(data, ..args) = cmarker.render(
   data,
-  math: mitex.mitex,
+  math: mitex-with-preamble.with(mitex-preamble: args.at("mitex-preamble", default: "")),
   // Like the std.image function, but 'preload' it with extra arguments
   // to resolve 'attachments'
   scope: (image: image-markdown-cell.with(..args)),

--- a/src/reading.typ
+++ b/src/reading.typ
@@ -53,6 +53,11 @@
 
 // Handler for simple text
 #let handler-text(data, ..args) = data
+#let mitex-with-preamble(content, mitex-preamble: "", ..mitex-args) = mitex.mitex.with(..mitex-args)({
+  // Add LaTeX preamble with all \newcommand expressions to each call
+  mitex-preamble
+  content
+})
 // Handler for Markdown markup
 #let handler-markdown(data, ..args) = cmarker.render(
   data,

--- a/src/rendering.typ
+++ b/src/rendering.typ
@@ -163,6 +163,8 @@
       output: output,
       input-args: input-args,
       output-args: output-args,
+      // Pass as extra argument. Other option: hide it in the cell metadata
+      mitex-preamble: processed-nb.metadata.callisto-preamble-mitex,
     )
   }
 }

--- a/src/templates.typ
+++ b/src/templates.typ
@@ -17,6 +17,7 @@
       handlers: handlers,
       // Extra arguments for handler
       attachments: cell.at("attachments", default: (:)),
+      mitex-preamble: args.at("mitex-preamble"),
     ).value,
   )
 }


### PR DESCRIPTION
Fixes #4

>In the meantime we could implement a "dirty" solution where we make a best effort to parse the Markdown code manually with a regex or something.

> To support simple cases we could extract a single "preamble" from the whole notebook and use it in every cell

Implemented like this :point_up: 